### PR TITLE
Deploying single files cannot be done through the variables

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -22,13 +22,12 @@ jobs:
       - name: Deploy index.html to S3
         uses: jakejarvis/s3-sync-action@master
         with:
-          args: --acl public-read --follow-symlinks --content-type text/html
+          args: --acl public-read --follow-symlinks --exclude '*' --include 'index.html' --content-type text/html
         env:
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: 'eu-west-1'
-          SOURCE_DIR: 'index.html'
           DEST_DIR: ''
 
       - name: Deploy XML to S3
@@ -81,13 +80,12 @@ jobs:
       - name: Deploy index.html to S3
         uses: jakejarvis/s3-sync-action@master
         with:
-          args: --acl public-read --follow-symlinks --content-type text/html
+          args: --acl public-read --follow-symlinks --exclude '*' --include 'index.html' --content-type text/html
         env:
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: 'eu-west-1'
-          SOURCE_DIR: 'index.html'
           DEST_DIR: ''
 
       - name: Deploy XML to S3


### PR DESCRIPTION
### Changed

* Documentation seems to be incorrect, SOURCE_DIR always refers to a directory. Single file deployments have to be performed through the command arguments, as per https://github.com/jakejarvis/s3-sync-action/issues/26#issuecomment-616894010
---

Ticket: https://jira.uitdatabank.be/browse/III-4549
