### PR TITLE
The github action checkout v2 uses deprecated nodejs 12, bump to v3

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.sha }}
 
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: Checkout project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.sha }}
 


### PR DESCRIPTION
### Changed

- Bump the checkout action to v3, to get rid of the deprecated NodeJS 12 warnings